### PR TITLE
Fix theme paths for GitHub Pages deployment

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -31,7 +31,7 @@ RECENT_POST_COUNT = 5
 THEME = 'themes/flex'
 
 # Flex theme specific settings
-SITELOGO = '/images/profile.png'  # You can add your profile image
+SITELOGO = 'images/profile.png'  # You can add your profile image
 SITETITLE = 'Panch Mukesh'
 SITESUBTITLE = 'Personal Website & Blog'
 SITEDESCRIPTION = 'Welcome to my personal website where I share my thoughts on technology, programming, and more.'
@@ -77,5 +77,5 @@ MARKDOWN = {
     'output_format': 'html5',
 }
 
-# Uncomment following line if you want document-relative URLs when developing
-# RELATIVE_URLS = True
+# Use relative URLs for proper theme loading
+RELATIVE_URLS = True

--- a/publishconf.py
+++ b/publishconf.py
@@ -9,7 +9,7 @@ from pelicanconf import *
 
 # If your site is available via HTTPS, make sure SITEURL begins with https://
 SITEURL = "https://mukeshpanch14.github.io/panch-portfolio"
-RELATIVE_URLS = False
+RELATIVE_URLS = True
 
 FEED_ALL_ATOM = "feeds/all.atom.xml"
 CATEGORY_FEED_ATOM = "feeds/{slug}.atom.xml"


### PR DESCRIPTION
- Enable RELATIVE_URLS in both pelicanconf.py and publishconf.py
- Change SITELOGO path from absolute to relative
- This ensures theme files and assets load correctly on GitHub Pages
- Theme paths now use ./theme/ instead of /theme/ for proper relative linking